### PR TITLE
refactor: introduce ports for persistence adapters

### DIFF
--- a/src/main/java/accessible_toilet/accessible_toilet/features/places/port/PlaceRepositoryPort.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/places/port/PlaceRepositoryPort.java
@@ -1,0 +1,15 @@
+package accessible_toilet.accessible_toilet.features.places.port;
+
+import accessible_toilet.accessible_toilet.features.places.domain.Place;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PlaceRepositoryPort {
+    Place save(Place place);
+
+    Optional<Place> findById(UUID id);
+
+    List<Place> findActiveWithin(double lat, double lon, int radiusMeters, int limit);
+}

--- a/src/main/java/accessible_toilet/accessible_toilet/features/places/repository/PlaceJpaRepository.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/places/repository/PlaceJpaRepository.java
@@ -17,7 +17,7 @@ import java.util.UUID;
  * limit  максимальное кол-во результатов
  * @return список мест
  */
-public interface PlaceRepository extends JpaRepository<Place, UUID> {
+public interface PlaceJpaRepository extends JpaRepository<Place, UUID> {
 
     // Быстрый geo-поиск через PostGIS: используем сгенерированную колонку `location`
     @Query(value = """

--- a/src/main/java/accessible_toilet/accessible_toilet/features/places/repository/PlaceRepositoryJpaAdapter.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/places/repository/PlaceRepositoryJpaAdapter.java
@@ -1,0 +1,32 @@
+package accessible_toilet.accessible_toilet.features.places.repository;
+
+import accessible_toilet.accessible_toilet.features.places.domain.Place;
+import accessible_toilet.accessible_toilet.features.places.port.PlaceRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class PlaceRepositoryJpaAdapter implements PlaceRepositoryPort {
+
+    private final PlaceJpaRepository placeRepository;
+
+    @Override
+    public Place save(Place place) {
+        return placeRepository.save(place);
+    }
+
+    @Override
+    public Optional<Place> findById(UUID id) {
+        return placeRepository.findById(id);
+    }
+
+    @Override
+    public List<Place> findActiveWithin(double lat, double lon, int radiusMeters, int limit) {
+        return placeRepository.findActiveWithin(lat, lon, radiusMeters, limit);
+    }
+}

--- a/src/main/java/accessible_toilet/accessible_toilet/features/places/service/PlaceServiceImpl.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/places/service/PlaceServiceImpl.java
@@ -7,8 +7,8 @@ import accessible_toilet.accessible_toilet.features.places.dto.CreatePlaceReques
 import accessible_toilet.accessible_toilet.features.places.dto.PlaceDetailResponse;
 import accessible_toilet.accessible_toilet.features.places.dto.PlaceShortResponse;
 import accessible_toilet.accessible_toilet.features.places.mapper.PlaceMapper;
+import accessible_toilet.accessible_toilet.features.places.port.PlaceRepositoryPort;
 import accessible_toilet.accessible_toilet.features.places.repository.PlaceMediaRepository;
-import accessible_toilet.accessible_toilet.features.places.repository.PlaceRepository;
 import accessible_toilet.accessible_toilet.features.users.domain.User;
 import accessible_toilet.accessible_toilet.features.users.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -27,7 +27,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class PlaceServiceImpl implements PlaceService {
 
-    private final PlaceRepository placeRepo;
+    private final PlaceRepositoryPort placeRepo;
     private final PlaceMediaRepository mediaRepo;
     private final UserRepository userRepo;
     private final PlaceMapper mapper;

--- a/src/main/java/accessible_toilet/accessible_toilet/features/ratings/port/RatingPort.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/ratings/port/RatingPort.java
@@ -1,0 +1,16 @@
+package accessible_toilet.accessible_toilet.features.ratings.port;
+
+import accessible_toilet.accessible_toilet.features.ratings.domain.PlaceRating;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RatingPort {
+    Optional<PlaceRating> findByPlaceIdAndUserId(UUID placeId, UUID userId);
+
+    PlaceRating save(PlaceRating rating);
+
+    double avgStars(UUID placeId);
+
+    long countByPlaceId(UUID placeId);
+}

--- a/src/main/java/accessible_toilet/accessible_toilet/features/ratings/repository/PlaceRatingJpaAdapter.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/ratings/repository/PlaceRatingJpaAdapter.java
@@ -1,0 +1,36 @@
+package accessible_toilet.accessible_toilet.features.ratings.repository;
+
+import accessible_toilet.accessible_toilet.features.ratings.domain.PlaceRating;
+import accessible_toilet.accessible_toilet.features.ratings.port.RatingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class PlaceRatingJpaAdapter implements RatingPort {
+
+    private final PlaceRatingJpaRepository repository;
+
+    @Override
+    public Optional<PlaceRating> findByPlaceIdAndUserId(UUID placeId, UUID userId) {
+        return repository.findByPlaceIdAndUserId(placeId, userId);
+    }
+
+    @Override
+    public PlaceRating save(PlaceRating rating) {
+        return repository.save(rating);
+    }
+
+    @Override
+    public double avgStars(UUID placeId) {
+        return repository.avgStars(placeId);
+    }
+
+    @Override
+    public long countByPlaceId(UUID placeId) {
+        return repository.countByPlaceId(placeId);
+    }
+}

--- a/src/main/java/accessible_toilet/accessible_toilet/features/ratings/repository/PlaceRatingJpaRepository.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/ratings/repository/PlaceRatingJpaRepository.java
@@ -12,7 +12,7 @@ import java.util.*;
  * - avgStars: Среднее количество звёзд по месту.
  * - countByPlaceId: Кол-во оценок по месту.
  */
-public interface PlaceRatingRepository extends JpaRepository<PlaceRating, UUID> {
+public interface PlaceRatingJpaRepository extends JpaRepository<PlaceRating, UUID> {
     Optional<PlaceRating> findByPlaceIdAndUserId(UUID placeId, UUID userId);
 
     @Query("select coalesce(avg(r.stars),0) from PlaceRating r where r.place.id = :placeId")

--- a/src/main/java/accessible_toilet/accessible_toilet/features/ratings/service/RatingServiceImpl.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/ratings/service/RatingServiceImpl.java
@@ -2,10 +2,10 @@ package accessible_toilet.accessible_toilet.features.ratings.service;
 
 import accessible_toilet.accessible_toilet.common.exception.NotFoundException;
 import accessible_toilet.accessible_toilet.features.places.domain.Place;
-import accessible_toilet.accessible_toilet.features.places.repository.PlaceRepository;
+import accessible_toilet.accessible_toilet.features.places.port.PlaceRepositoryPort;
 import accessible_toilet.accessible_toilet.features.ratings.domain.PlaceRating;
 import accessible_toilet.accessible_toilet.features.ratings.dto.RateRequest;
-import accessible_toilet.accessible_toilet.features.ratings.repository.PlaceRatingRepository;
+import accessible_toilet.accessible_toilet.features.ratings.port.RatingPort;
 import accessible_toilet.accessible_toilet.features.users.domain.User;
 import accessible_toilet.accessible_toilet.features.users.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -19,8 +19,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class RatingServiceImpl implements RatingService {
 
-    private final PlaceRepository placeRepo;
-    private final PlaceRatingRepository ratingRepo;
+    private final PlaceRepositoryPort placeRepo;
+    private final RatingPort ratingRepo;
     private final UserRepository userRepo;
 
     @Override

--- a/src/main/java/accessible_toilet/accessible_toilet/features/verifications/port/VerificationPort.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/verifications/port/VerificationPort.java
@@ -1,0 +1,13 @@
+package accessible_toilet.accessible_toilet.features.verifications.port;
+
+import accessible_toilet.accessible_toilet.features.verifications.domain.PlaceVerification;
+
+import java.util.UUID;
+
+public interface VerificationPort {
+    boolean existsByPlaceIdAndReviewerId(UUID placeId, UUID reviewerId);
+
+    PlaceVerification save(PlaceVerification verification);
+
+    long countByPlaceIdAndDecision(UUID placeId, PlaceVerification.Decision decision);
+}

--- a/src/main/java/accessible_toilet/accessible_toilet/features/verifications/repository/PlaceVerificationJpaAdapter.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/verifications/repository/PlaceVerificationJpaAdapter.java
@@ -1,0 +1,30 @@
+package accessible_toilet.accessible_toilet.features.verifications.repository;
+
+import accessible_toilet.accessible_toilet.features.verifications.domain.PlaceVerification;
+import accessible_toilet.accessible_toilet.features.verifications.port.VerificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class PlaceVerificationJpaAdapter implements VerificationPort {
+
+    private final PlaceVerificationJpaRepository repository;
+
+    @Override
+    public boolean existsByPlaceIdAndReviewerId(UUID placeId, UUID reviewerId) {
+        return repository.existsByPlaceIdAndReviewerId(placeId, reviewerId);
+    }
+
+    @Override
+    public PlaceVerification save(PlaceVerification verification) {
+        return repository.save(verification);
+    }
+
+    @Override
+    public long countByPlaceIdAndDecision(UUID placeId, PlaceVerification.Decision decision) {
+        return repository.countByPlaceIdAndDecision(placeId, decision);
+    }
+}

--- a/src/main/java/accessible_toilet/accessible_toilet/features/verifications/repository/PlaceVerificationJpaRepository.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/verifications/repository/PlaceVerificationJpaRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
  * - existsByPlaceIdAndReviewerId: Проверка, голосовал ли уже пользователь за это место.
  * - countByPlaceIdAndDecision: Подсчёт голосов по типу решения.
  */
-public interface PlaceVerificationRepository extends JpaRepository<PlaceVerification, UUID> {
+public interface PlaceVerificationJpaRepository extends JpaRepository<PlaceVerification, UUID> {
     boolean existsByPlaceIdAndReviewerId(UUID placeId, UUID reviewerId);
     long countByPlaceIdAndDecision(UUID placeId, PlaceVerification.Decision decision);
 }

--- a/src/main/java/accessible_toilet/accessible_toilet/features/verifications/service/VerificationServiceImpl.java
+++ b/src/main/java/accessible_toilet/accessible_toilet/features/verifications/service/VerificationServiceImpl.java
@@ -3,12 +3,12 @@ package accessible_toilet.accessible_toilet.features.verifications.service;
 import accessible_toilet.accessible_toilet.common.exception.BadRequestException;
 import accessible_toilet.accessible_toilet.common.exception.NotFoundException;
 import accessible_toilet.accessible_toilet.features.places.domain.Place;
-import accessible_toilet.accessible_toilet.features.places.repository.PlaceRepository;
+import accessible_toilet.accessible_toilet.features.places.port.PlaceRepositoryPort;
 import accessible_toilet.accessible_toilet.features.users.domain.User;
 import accessible_toilet.accessible_toilet.features.users.repository.UserRepository;
 import accessible_toilet.accessible_toilet.features.verifications.domain.PlaceVerification;
 import accessible_toilet.accessible_toilet.features.verifications.dto.VerifyRequest;
-import accessible_toilet.accessible_toilet.features.verifications.repository.PlaceVerificationRepository;
+import accessible_toilet.accessible_toilet.features.verifications.port.VerificationPort;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +20,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class VerificationServiceImpl implements VerificationService {
 
-    private final PlaceRepository placeRepo;
-    private final PlaceVerificationRepository verRepo;
+    private final PlaceRepositoryPort placeRepo;
+    private final VerificationPort verRepo;
     private final UserRepository userRepo;
 
     @Override


### PR DESCRIPTION
добавлены выделенные порты для постоянного доступа к местоположению, рейтингу и проверке
предоставлены  адаптеры JPA, которые реализуют новые порты и обновляют службы, зависящие от них
переименованы  хранилища данных Spring в типы, зависящие от JPA, для поддержки адаптеров